### PR TITLE
Only consider objects that are attached to gripper in place action

### DIFF
--- a/manipulation_pipeline/include/manipulation_pipeline/planning_steps/place.h
+++ b/manipulation_pipeline/include/manipulation_pipeline/planning_steps/place.h
@@ -43,6 +43,9 @@
 
 namespace manipulation_pipeline {
 
+class GroupInterface;
+
+
 /*! \brief Place a previously grasped object at a specific cartesian pose
  */
 class Place : public ActionPlanningStep<manipulation_pipeline_interfaces::action::Place>
@@ -65,6 +68,7 @@ public:
 private:
   const moveit::core::AttachedBody*
   getAttachedBody(const std::string& name,
+                  const GroupInterface& ee,
                   const planning_scene::PlanningScene& planning_scene) const;
 };
 

--- a/manipulation_pipeline/src/planning_steps/place.cpp
+++ b/manipulation_pipeline/src/planning_steps/place.cpp
@@ -69,8 +69,9 @@ Place::plan(const RobotModel& robot_model,
   Planner planner{planning_interface, context, params, limits, m_log};
 
   // Get attached object
-  const auto& attached_body = *getAttachedBody(m_goal->object_name, *context.planning_scene);
-  const auto* tip_link      = attached_body.getAttachedLink();
+  const auto& attached_body =
+    *getAttachedBody(m_goal->object_name, ee_interface, *context.planning_scene);
+  const auto* tip_link = attached_body.getAttachedLink();
 
   // Get tip offset
   const auto tip_offset = attached_body.getPose();
@@ -255,15 +256,17 @@ Place::plan(const RobotModel& robot_model,
 
 const moveit::core::AttachedBody*
 Place::getAttachedBody(const std::string& name,
+                       const GroupInterface& ee,
                        const planning_scene::PlanningScene& planning_scene) const
 {
   // Get all attached bodies
   std::vector<const moveit::core::AttachedBody*> attached_bodies;
-  planning_scene.getCurrentState().getAttachedBodies(attached_bodies);
+  planning_scene.getCurrentState().getAttachedBodies(attached_bodies, ee.group());
 
   if (attached_bodies.empty())
   {
-    throw std::runtime_error{"There are currently no attached objects"};
+    throw std::runtime_error{
+      fmt::format("There are currently no objects attached to group {}", ee.name())};
   }
 
   // Try default object


### PR DESCRIPTION
Before, default-selection of objects did not work if any additional objects were attached to any link in the scene.