### PR TITLE
Fix order of waypoints in approach

### DIFF
--- a/manipulation_pipeline/src/planning_steps/grasp.cpp
+++ b/manipulation_pipeline/src/planning_steps/grasp.cpp
@@ -100,8 +100,8 @@ Grasp::plan(const RobotModel& robot_model,
   const auto target_pose = collision_object_to_reference_transform * target_pose_local;
 
   // Get waypoints for approach and retraction
-  const auto approach_waypoints = convertLinearMotion(m_goal->approach, target_pose);
-  const auto retract_waypoints  = convertLinearMotion(m_goal->retract, target_pose);
+  auto approach_waypoints      = convertLinearMotion(m_goal->approach, target_pose);
+  const auto retract_waypoints = convertLinearMotion(m_goal->retract, target_pose);
 
   // Resolve cartesian limits
   const auto approach_limits = applyCartesianLimits(m_goal->approach.limits, limits);
@@ -142,6 +142,9 @@ Grasp::plan(const RobotModel& robot_model,
   attached_collision_object.object.operation = moveit_msgs::msg::CollisionObject::ADD;
   attached_collision_object.link_name        = tip_link->getName();
   attached_collision_object.touch_links      = ee_link_names;
+
+  // We plan in reverse, starting from ik at target pose
+  std::reverse(approach_waypoints.begin(), approach_waypoints.end());
 
   const auto initial_state          = context.planning_scene->getCurrentState();
   moveit::core::RobotState ik_state = initial_state;

--- a/manipulation_pipeline/src/planning_steps/place.cpp
+++ b/manipulation_pipeline/src/planning_steps/place.cpp
@@ -98,8 +98,8 @@ Place::plan(const RobotModel& robot_model,
 
   const auto target_pose = local_to_reference_transform * target_pose_local;
 
-  const auto approach_waypoints = convertLinearMotion(m_goal->approach, target_pose);
-  const auto retract_waypoints  = convertLinearMotion(m_goal->retract, target_pose);
+  auto approach_waypoints      = convertLinearMotion(m_goal->approach, target_pose);
+  const auto retract_waypoints = convertLinearMotion(m_goal->retract, target_pose);
 
   // Messages for collision object removal
   // If we want to attach the object to a different link afterwards, we need seperate REMOVE and ADD
@@ -142,6 +142,9 @@ Place::plan(const RobotModel& robot_model,
   // Target pose for setFromIk needs to be in model frame
   geometry_msgs::msg::Pose target_pose_msg;
   tf2::convert(reference_frame_transform * target_pose, target_pose_msg);
+
+  // We plan the approach motion in reverse
+  std::reverse(approach_waypoints.begin(), approach_waypoints.end());
 
   const auto initial_state          = context.planning_scene->getCurrentState();
   moveit::core::RobotState ik_state = initial_state;


### PR DESCRIPTION
As we plan approach in reverse, we need to flip the order of waypoints.